### PR TITLE
Fix Unicode-objects must be encoded before hashing

### DIFF
--- a/banditParser.py
+++ b/banditParser.py
@@ -7,7 +7,7 @@ import argparse
 
 def hash(toHash):
 	hash_object = hashlib.sha256()
-	hash_object.update(toHash)
+	hash_object.update(toHash.encode('utf8'))
 	hex_dig = hash_object.hexdigest()
 	return hex_dig
 


### PR DESCRIPTION
My python3 build is currently failing because of this. https://travis-ci.com/github/zendesk/zopim-pimp/jobs/353463464