### PR TITLE
Use pip for backward compatibility

### DIFF
--- a/scripts/bandit.sh
+++ b/scripts/bandit.sh
@@ -4,7 +4,12 @@ set -v
 
 echo 'Installing bandit'
 #pip install --user bandit
-pip3 install bandit
+if [ -x "$(command -v pip3)" ]; then
+    pip3 install bandit
+else
+    pip install --user bandit
+fi
+
 
 echo 'Running Bandit tests'
 bandit -r --ini .bandit -f json -o banditResult.json .


### PR DESCRIPTION
Using pip command for backward compatibility 

Currently  travis job failing for zopim-allura repo, due to change from pip to pip3, this change allows backward compatibility

CC
@zendesk/fangorn 